### PR TITLE
Fixes #8 also on windows.

### DIFF
--- a/com.palantir.typescript/src/com/palantir/typescript/text/TypeScriptEditor.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/text/TypeScriptEditor.java
@@ -313,7 +313,7 @@ public final class TypeScriptEditor extends TextEditor {
         } else if (input instanceof FileStoreEditorInput) {
             FileStoreEditorInput editorInput = (FileStoreEditorInput) input;
 
-            return editorInput.getURI().getPath();
+            return new File(editorInput.getURI()).getAbsolutePath();
         }
 
         throw new UnsupportedOperationException();


### PR DESCRIPTION
Opening files outside the workspace on my windows maching did not work, as the filename passed to the LanguageService was invalid (something like "/C:/test/test.ts") and it was rejected by IO.readFile. I suspect that this is a windows only problem, but I'm not sure. 

The proposed patch, however, should be OS independent.
