### PR TITLE
Fixes #11 Exclude resource not in source folders in full builds.

### DIFF
--- a/com.palantir.typescript/src/com/palantir/typescript/BuildPathPropertyPage.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/BuildPathPropertyPage.java
@@ -62,13 +62,20 @@ public final class BuildPathPropertyPage extends PropertyPage {
     public boolean performOk() {
         IEclipsePreferences projectPreferences = this.getProjectPreferences();
 
-        projectPreferences.put(IPreferenceConstants.COMPILER_OUTPUT_DIR_OPTION, this.outputFolderField.getText());
-        projectPreferences.put(IPreferenceConstants.BUILD_PATH_SOURCE_FOLDER, this.sourceFolderField.getText());
+        String oldPathValue = projectPreferences.get(IPreferenceConstants.BUILD_PATH_SOURCE_FOLDER, "");
+        String oldOutputValue = projectPreferences.get(IPreferenceConstants.COMPILER_OUTPUT_DIR_OPTION, "");
 
-        try {
-            projectPreferences.flush();
-        } catch (BackingStoreException e) {
-            throw new RuntimeException(e);
+        if (!oldPathValue.equals(this.outputFolderField.getText()) || !oldOutputValue.equals(this.sourceFolderField.getText())){
+            projectPreferences.put(IPreferenceConstants.COMPILER_OUTPUT_DIR_OPTION, this.outputFolderField.getText());
+            projectPreferences.put(IPreferenceConstants.BUILD_PATH_SOURCE_FOLDER, this.sourceFolderField.getText());
+
+            try {
+                projectPreferences.flush();
+            } catch (BackingStoreException e) {
+                throw new RuntimeException(e);
+            }
+
+            BuildUtils.rebuildProject((IProject) this.getElement().getAdapter(IProject.class));
         }
 
         return true;


### PR DESCRIPTION
Also forces a project full build on build path changes.

The following error was generated when forcing a full build with a configured source path:

```
java.lang.RuntimeException: The following request caused an error to be thrown:
{"service":"language","method":"getEmitOutput","arguments":["C:\\Users\\rserafin\\runtime-EclipseApplication\\test\\target\\classes\\test.ts"]}
TypeError: Cannot call method 'diagnostics' of null
    at TypeScriptCompiler.getSyntacticDiagnostics (C:\Users\rserafin\external_workspace\eclipse-typescript\com.palantir.typescript\bin\bridge.js:54217:47)
    at CompilerState.getSyntacticDiagnostics (C:\Users\rserafin\external_workspace\eclipse-typescript\com.palantir.typescript\bin\bridge.js:58075:34)
    at CompilerState.getEmitOutput (C:\Users\rserafin\external_workspace\eclipse-typescript\com.palantir.typescript\bin\bridge.js:58139:58)
    at LanguageService.getEmitOutput (C:\Users\rserafin\external_workspace\eclipse-typescript\com.palantir.typescript\bin\bridge.js:59400:39)
    at LanguageService.getEmitOutput (C:\Users\rserafin\external_workspace\eclipse-typescript\com.palantir.typescript\bin\bridge.js:63501:41)
```

I've fixed it "in-line" in the TypescriptBuilder class, but I suggest to refactor the code and pull together resource filtering (as I did in my original pull request, still available in my master branch). 
