### PR TITLE
Fixed problem rebuilding workspace with closed projects.

### DIFF
--- a/com.palantir.typescript/src/com/palantir/typescript/BuildUtils.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/BuildUtils.java
@@ -46,7 +46,9 @@ public final class BuildUtils {
                 try {
                     final IProject[] projects = workspace.getRoot().getProjects();
                     for (final IProject proj : projects) {
-                        BuildUtils.rebuildProject(proj, monitor);
+                        if (proj.isOpen()){
+                            BuildUtils.rebuildProject(proj, monitor);
+                        }
                     }
                 } catch (final CoreException e) {
                     return e.getStatus();


### PR DESCRIPTION
Fixes a problem when changing the compiler preferences and starting a full
rebuild of the workspace, in case the workspace contains closed projects.
