### PR TITLE
Add project export folder, and include it in compilation

### DIFF
--- a/com.palantir.typescript/src/com/palantir/typescript/IPreferenceConstants.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/IPreferenceConstants.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
  */
 public interface IPreferenceConstants {
 
+    String BUILD_PATH_EXPORT_FOLDER = "build.path.exportFolder";
     String BUILD_PATH_SOURCE_FOLDER = "build.path.sourceFolder";
 
     String COMPILER_CODE_GEN_TARGET = "compiler.codeGenTarget";

--- a/com.palantir.typescript/src/com/palantir/typescript/preferences/BuildPathPropertyPage.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/preferences/BuildPathPropertyPage.java
@@ -58,6 +58,7 @@ import com.palantir.typescript.TypeScriptPlugin;
  */
 public final class BuildPathPropertyPage extends PropertyPage {
 
+    private Text exportFolderField;
     private Text outputFileField;
     private Text outputFolderField;
     private Text sourceFolderField;
@@ -66,14 +67,20 @@ public final class BuildPathPropertyPage extends PropertyPage {
     public boolean performOk() {
         IEclipsePreferences projectPreferences = this.getProjectPreferences();
         String oldSourceFolder = projectPreferences.get(IPreferenceConstants.BUILD_PATH_SOURCE_FOLDER, "");
+        String oldExportFolder = projectPreferences.get(IPreferenceConstants.BUILD_PATH_EXPORT_FOLDER, "");
         String oldOutputFile = projectPreferences.get(IPreferenceConstants.COMPILER_OUTPUT_FILE_OPTION, "");
         String oldOutputFolder = projectPreferences.get(IPreferenceConstants.COMPILER_OUTPUT_DIR_OPTION, "");
+        String newExportFolder = this.exportFolderField.getText();
         String newSourceFolder = this.sourceFolderField.getText();
         String newOutputFile = this.outputFileField.getText();
         String newOutputFolder = this.outputFolderField.getText();
 
-        if (!oldSourceFolder.equals(newSourceFolder) || !oldOutputFile.equals(newOutputFile) || !oldOutputFolder.equals(newOutputFolder)) {
+        if (!oldSourceFolder.equals(newSourceFolder)
+                || !oldExportFolder.equals(newExportFolder)
+                || !oldOutputFile.equals(newOutputFile)
+                || !oldOutputFolder.equals(newOutputFolder)) {
             projectPreferences.put(IPreferenceConstants.BUILD_PATH_SOURCE_FOLDER, newSourceFolder);
+            projectPreferences.put(IPreferenceConstants.BUILD_PATH_EXPORT_FOLDER, newExportFolder);
             projectPreferences.put(IPreferenceConstants.COMPILER_OUTPUT_DIR_OPTION, newOutputFolder);
             projectPreferences.put(IPreferenceConstants.COMPILER_OUTPUT_FILE_OPTION, newOutputFile);
 
@@ -99,7 +106,8 @@ public final class BuildPathPropertyPage extends PropertyPage {
         composite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
         composite.setFont(parent.getFont());
 
-        this.sourceFolderField = this.createFolderField(composite, SWT.NONE, "Source folder:", IPreferenceConstants.BUILD_PATH_SOURCE_FOLDER);
+        this.sourceFolderField = this.createFolderField(composite, SWT.NONE, "Source folder(s):", IPreferenceConstants.BUILD_PATH_SOURCE_FOLDER);
+        this.exportFolderField = this.createFolderField(composite, SWT.NONE, "Exported folder(s):", IPreferenceConstants.BUILD_PATH_EXPORT_FOLDER);
         this.outputFolderField = this.createFolderField(composite, SWT.PUSH, "Output folder:", IPreferenceConstants.COMPILER_OUTPUT_DIR_OPTION);
         this.outputFileField = this.createFileField(composite, SWT.PUSH, "Output file name:", IPreferenceConstants.COMPILER_OUTPUT_FILE_OPTION);
 

--- a/com.palantir.typescript/src/com/palantir/typescript/services/language/CompilationSettings.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/services/language/CompilationSettings.java
@@ -235,12 +235,12 @@ public final class CompilationSettings {
         if (!Strings.isNullOrEmpty(outputDir)) {
             IFolder outputFolder = project.getFolder(outputDir);
 
-            outputFolderName = EclipseResources.getFolderName(outputFolder);
+            outputFolderName = EclipseResources.getContainerName(outputFolder);
         }
 
         if (!Strings.isNullOrEmpty(outputFile)) {
             if (outputFolderName == null) {
-                outputFolderName = EclipseResources.getProjectName(project);
+                outputFolderName = EclipseResources.getContainerName(project);
             }
 
             compilationSettings.setOutFileOption(outputFolderName + outputFile);


### PR DESCRIPTION
- Add build path preference for each project
- Pass export folders and referenced projects to language endpoint
- Check them in the project language service's fileFilter
