### PR TITLE
Add debugger mode to the Node bridge

### DIFF
--- a/tasks/tsc.js
+++ b/tasks/tsc.js
@@ -12,6 +12,7 @@ module.exports = function(grunt) {
     var options = this.options();
     var args = [];
 
+    args.push("--sourcemap");
     this.files.forEach(function(file) {
       file.src.filter(function(filepath) {
         args.push(filepath);


### PR DESCRIPTION
Uses node-inspector to run a browser-based debugger.
