### PR TITLE
Fix cross-project compilation

### DIFF
--- a/com.palantir.typescript/src/com/palantir/typescript/EclipseResources.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/EclipseResources.java
@@ -254,6 +254,10 @@ public final class EclipseResources {
         return resource.getType() == IResource.FILE && resource.getName().endsWith(".ts");
     }
 
+    public static boolean isTypeScriptDefinitionFile(IResource resource) {
+        return resource.getType() == IResource.FILE && resource.getName().endsWith(".d.ts");
+    }
+
     private static final class MyResourceDeltaVisitor implements IResourceDeltaVisitor {
 
         /*


### PR DESCRIPTION
Resolves #173 (with a workaround--only export the built .d.ts files), and fixes #175.

I've tested this as thoroughly as I could think to:
- Starting from fresh, unbuilt projects, importing them, and turning on "build automatically", everything builds correctly.
- I opened a source file in `core`, changed a method name and saved, and everything rebuilt correctly, with errors popping up in both `core` and `app`.
- Changing that method name back fixed everything correctly in referencing projects.
- Build output is going to the right directory.
- I cleaned everything (and removed the build folders), and turned off "build automatically". Then, building `testlib` triggered a build for `core` (since `testlib` depends on `core`).

Any thoughts? With this implementation, LanguageEndpoint.updateFiles is being called once for every source file that gets compiled. I could see if there's a better way to do it if you think that will be problematic, but it seems to work fine.

Let me know what you think.
