### PR TITLE
Added task marker for XXX, FIXME and TODO comments

### DIFF
--- a/com.palantir.typescript/bridge/src/languageEndpoint.ts
+++ b/com.palantir.typescript/bridge/src/languageEndpoint.ts
@@ -80,6 +80,33 @@ module Bridge {
             delete this.languageServices[serviceKey];
         }
 
+        public getAllTodos(projectName: string) {
+            var todos: { [fileName: string]: TodoCommentEx[] } = {};
+            Object.keys(this.fileInfos)
+                .filter((fileName) => this.isSourceFile(projectName, fileName))
+                .forEach((fileName) => {
+                	todos[fileName] = this.getTodos(projectName, fileName);
+            	});
+            return todos;
+        }
+
+        public getTodos(serviceKey: string, filename: string): TodoCommentEx[] {
+            var todos = this.languageServices[serviceKey].getTodoComments(filename,
+                [{ text: "TODO", priority: 0 }, { text: "FIXME", priority: 1 }, { text: "XXX", priority: 2 }]);
+            if (todos.length) {
+                var file = this.languageServices[serviceKey].getSourceFile(filename);
+                return todos.map((todo) => {
+                    return {
+                        start: todo.position,
+                        line: file.getLineAndCharacterFromPosition(todo.position).line,
+                        priority: todo.descriptor.priority,
+                        text: todo.message
+                    };
+                });
+            }
+            return [];
+        }
+
         public getAllDiagnostics(projectName: string) {
             var diagnostics: { [fileName: string]: DiagnosticEx[] } = {};
 
@@ -330,6 +357,13 @@ module Bridge {
         length: number;
         line: number;
         start: number;
+        text: string;
+    }
+
+    export interface TodoCommentEx {
+        start: number;
+        line: number;
+        priority: number;
         text: string;
     }
 

--- a/com.palantir.typescript/plugin.xml
+++ b/com.palantir.typescript/plugin.xml
@@ -48,6 +48,16 @@
             value="true">
       </persistent>
    </extension>
+   <extension
+         id="typeScriptTask"
+         name="TypeScript Task"
+         point="org.eclipse.core.resources.markers">
+		<super type="org.eclipse.core.resources.taskmarker"/>
+		<super type="org.eclipse.core.resources.textmarker"/>      
+		<persistent
+            value="true">
+      </persistent>
+   </extension>
 
    <extension
          id="typeScriptNature"
@@ -217,7 +227,13 @@
       <type
             name="com.palantir.typescript.occurrences">
       </type>
+      <type
+            name="com.palantir.typescript.task"
+            markerType="com.palantir.typescript.typeScriptTask"
+            super="org.eclipse.ui.workbench.texteditor.task">
+      </type>
    </extension>
+
 
    <extension
          point="org.eclipse.ui.editors.markerAnnotationSpecification">

--- a/com.palantir.typescript/src/com/palantir/typescript/services/language/LanguageEndpoint.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/services/language/LanguageEndpoint.java
@@ -112,6 +112,16 @@ public final class LanguageEndpoint {
         return this.bridge.call(request, returnType);
     }
 
+    public Map<String, List<TodoCommentEx>> getAllTodos(IProject project){
+        checkNotNull(project);
+        String projectName = project.getName();
+        Request request = new Request(SERVICE, "getAllTodos", projectName);
+        JavaType stringType = TypeFactory.defaultInstance().uncheckedSimpleType(String.class);
+        CollectionType todoListType = TypeFactory.defaultInstance().constructCollectionType(List.class, TodoCommentEx.class);
+        MapType returnType = TypeFactory.defaultInstance().constructMapType(Map.class, stringType, todoListType);
+        return this.bridge.call(request, returnType);
+    }
+
     public List<OutputFile> getEmitOutput(IProject project, String fileName) {
         checkNotNull(fileName);
 
@@ -187,6 +197,15 @@ public final class LanguageEndpoint {
 
         Request request = new Request(SERVICE, "getDiagnostics", serviceKey, fileName, semantic);
         CollectionType resultType = TypeFactory.defaultInstance().constructCollectionType(List.class, DiagnosticEx.class);
+        return this.bridge.call(request, resultType);
+    }
+
+    public List<TodoCommentEx> getTodos(String serviceKey, String fileName) {
+        checkNotNull(serviceKey);
+        checkNotNull(fileName);
+
+        Request request = new Request(SERVICE, "getTodos", serviceKey, fileName);
+        CollectionType resultType = TypeFactory.defaultInstance().constructCollectionType(List.class, TodoCommentEx.class);
         return this.bridge.call(request, resultType);
     }
 

--- a/com.palantir.typescript/src/com/palantir/typescript/services/language/TodoCommentEx.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/services/language/TodoCommentEx.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.typescript.services.language;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+
+/**
+ * Corresponds to the class with the same name in languageService.ts.
+ *
+ * @author tony.benbrahim <tony.benbrahim@10xdev.com>
+ */
+public final class TodoCommentEx {
+
+    private final int start;
+    private final int line;
+    private final int priority;
+    private final String text;
+
+    public TodoCommentEx(
+            @JsonProperty("start") int start,
+            @JsonProperty("line") int line,
+            @JsonProperty("priority") int priority,
+            @JsonProperty("text") String text) {
+        checkArgument(line >= 0);
+        checkArgument(start >= 0);
+        checkArgument(priority >=0 && priority<=2);
+
+        this.start = start;
+        this.line = line;
+        this.priority = priority;
+        this.text = text;
+    }
+
+    public int getStart() {
+        return this.start;
+    }
+
+    public int getLine() {
+        return this.line;
+    }
+
+    public int getPriority() {
+        return this.priority;
+    }
+
+    public String getText() {
+        return this.text;
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this)
+            .add("start", this.start)
+            .add("line", this.line)
+            .add("priority", this.priority)
+            .add("text", this.text)
+            .toString();
+    }
+}

--- a/com.palantir.typescript/src/com/palantir/typescript/text/FileLanguageService.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/text/FileLanguageService.java
@@ -36,6 +36,7 @@ import com.palantir.typescript.services.language.ReferenceEntryEx;
 import com.palantir.typescript.services.language.RenameLocation;
 import com.palantir.typescript.services.language.TextChange;
 import com.palantir.typescript.services.language.TextSpan;
+import com.palantir.typescript.services.language.TodoCommentEx;
 
 /**
  * A language service specifically for use with a single file.
@@ -91,6 +92,10 @@ public final class FileLanguageService {
         boolean semantic = !this.serviceKey.equals(this.fileName);
 
         return this.languageEndpoint.getDiagnostics(this.serviceKey, this.fileName, semantic);
+    }
+
+    public List<TodoCommentEx> getTodos() {
+        return this.languageEndpoint.getTodos(this.serviceKey, this.fileName);
     }
 
     public List<TextChange> getFormattingEditsForRange(int start, int end, FormatCodeOptions options) {


### PR DESCRIPTION
This PR creates a "TypeScript Task" task type, shows tasks annotations in the margin of source files, and shows the entries in the Tasks and Markers view

Currently supports XXX, FIXME and TODO in comments
(I am not crazy about XXX, but apparently people use it, I think I would rather have FIXME as high priority and TODO as normal priority)
![tasks](https://cloud.githubusercontent.com/assets/1153429/6096945/f21e88f8-af6e-11e4-8654-458889c7a0fd.png)


