### PR TITLE
added the missing bits to enable --suppressImplicitAnyIndexErrors support

### DIFF
--- a/com.palantir.typescript/src/com/palantir/typescript/IPreferenceConstants.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/IPreferenceConstants.java
@@ -34,6 +34,7 @@ public interface IPreferenceConstants {
     String COMPILER_MODULE = "compiler.moduleGenTarget";
     String COMPILER_NO_EMIT_ON_ERROR = "compiler.noEmitOnError";
     String COMPILER_NO_IMPLICIT_ANY = "compiler.noImplicitAny";
+    String COMPILER_SUPPRESS_IMPLICIT_ANY_INDEX_ERRORS = "compiler.suppressImplicitAnyIndexErrors";
     String COMPILER_NO_LIB = "compiler.noLib";
     String COMPILER_OUT_DIR = "compiler.outputDirOption";
     String COMPILER_OUT_FILE = "compiler.outputFileOption";

--- a/com.palantir.typescript/src/com/palantir/typescript/TypeScriptPlugin.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/TypeScriptPlugin.java
@@ -152,6 +152,7 @@ public final class TypeScriptPlugin extends AbstractUIPlugin {
         store.setDefault(IPreferenceConstants.COMPILER_SOURCE_MAP, false);
         store.setDefault(IPreferenceConstants.COMPILER_MODULE, ModuleKind.UNSPECIFIED.toString());
         store.setDefault(IPreferenceConstants.COMPILER_NO_IMPLICIT_ANY, false);
+        store.setDefault(IPreferenceConstants.COMPILER_SUPPRESS_IMPLICIT_ANY_INDEX_ERRORS, false);
         store.setDefault(IPreferenceConstants.COMPILER_NO_LIB, false);
         store.setDefault(IPreferenceConstants.COMPILER_REMOVE_COMMENTS, false);
 

--- a/com.palantir.typescript/src/com/palantir/typescript/preferences/CompilerPreferencePage.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/preferences/CompilerPreferencePage.java
@@ -53,6 +53,7 @@ public final class CompilerPreferencePage extends FieldEditorProjectPreferencePa
     private ComboFieldEditor moduleField;
     private BooleanFieldEditor noEmitOnErrorField;
     private BooleanFieldEditor noImplicitAnyField;
+    private BooleanFieldEditor suppressImplicitAnyIndexErrorsField;
     private BooleanFieldEditor noLibField;
     private BooleanFieldEditor removeCommentsField;
     private BooleanFieldEditor sourceMapField;
@@ -154,6 +155,12 @@ public final class CompilerPreferencePage extends FieldEditorProjectPreferencePa
             getResource("no.implicit.any"),
             this.getFieldEditorParent());
         this.addField(this.noImplicitAnyField);
+
+        this.suppressImplicitAnyIndexErrorsField = new BooleanFieldEditor(
+            IPreferenceConstants.COMPILER_SUPPRESS_IMPLICIT_ANY_INDEX_ERRORS,
+            getResource("suppress.implicit.any.index.errors"),
+            this.getFieldEditorParent());
+        this.addField(this.suppressImplicitAnyIndexErrorsField);
 
         this.noLibField = new BooleanFieldEditor(
             IPreferenceConstants.COMPILER_NO_LIB,

--- a/com.palantir.typescript/src/com/palantir/typescript/resources.properties
+++ b/com.palantir.typescript/src/com/palantir/typescript/resources.properties
@@ -21,6 +21,7 @@ preferences.compiler.declaration = Generate corresponding .d.ts files
 preferences.compiler.module = Module code generation:
 preferences.compiler.no.emit.on.error = Do not emit outputs if any type checking errors were reported
 preferences.compiler.no.implicit.any = Raise error on expressions and declarations with an implied 'any' type
+preferences.compiler.suppress.implicit.any.index.errors = Suppress noImplicitAny errors for indexing objects lacking index signatures
 preferences.compiler.no.lib = Do not include the default library (lib.d.ts) when compiling
 preferences.compiler.remove.comments = Do not emit comments to output
 preferences.compiler.source.map = Generate corresponding .map files

--- a/com.palantir.typescript/src/com/palantir/typescript/services/language/CompilerOptions.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/services/language/CompilerOptions.java
@@ -127,6 +127,7 @@ public final class CompilerOptions {
         compilationSettings.module = ModuleKind.valueOf(preferenceStore.getString(IPreferenceConstants.COMPILER_MODULE));
         compilationSettings.noEmitOnError = preferenceStore.getBoolean(IPreferenceConstants.COMPILER_NO_EMIT_ON_ERROR);
         compilationSettings.noImplicitAny = preferenceStore.getBoolean(IPreferenceConstants.COMPILER_NO_IMPLICIT_ANY);
+        compilationSettings.suppressImplicitAnyIndexErrors = preferenceStore.getBoolean(IPreferenceConstants.COMPILER_SUPPRESS_IMPLICIT_ANY_INDEX_ERRORS);
         compilationSettings.noLib = preferenceStore.getBoolean(IPreferenceConstants.COMPILER_NO_LIB);
         compilationSettings.removeComments = preferenceStore.getBoolean(IPreferenceConstants.COMPILER_REMOVE_COMMENTS);
         compilationSettings.sourceMap = preferenceStore.getBoolean(IPreferenceConstants.COMPILER_SOURCE_MAP);


### PR DESCRIPTION
A few bits and bobs to enable support for --suppressImplicitAnyIndexErrors. Most of the code has already been there so this is the UI and some support code only.

Note: the help text (Suppress noImplicitAny errors for indexing objects lacking index signatures) may need tweaking as the 'noImplicitAny errors' bit doesn't make much sense to someone not familiar with the tsc command line options.