### PR TITLE
Revert "Collapse/expand all in Outline view. Fix for #162"

### DIFF
--- a/com.palantir.typescript/META-INF/MANIFEST.MF
+++ b/com.palantir.typescript/META-INF/MANIFEST.MF
@@ -18,8 +18,7 @@ Require-Bundle: org.eclipse.compare,
  org.eclipse.ui.editors,
  org.eclipse.ui.ide,
  org.eclipse.ui.views,
- org.eclipse.ui.workbench.texteditor,
- org.eclipse.jdt.ui
+ org.eclipse.ui.workbench.texteditor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: lib/guava-15.0.jar,

--- a/com.palantir.typescript/src/com/palantir/typescript/text/OutlinePage.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/text/OutlinePage.java
@@ -20,8 +20,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.List;
 
-import org.eclipse.jdt.internal.ui.actions.CollapseAllAction;
-import org.eclipse.jface.action.IToolBarManager;
 import org.eclipse.jface.text.TextSelection;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
@@ -29,17 +27,14 @@ import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.viewers.TreePath;
 import org.eclipse.jface.viewers.TreeSelection;
 import org.eclipse.jface.viewers.TreeViewer;
-import org.eclipse.search2.internal.ui.basic.views.ExpandAllAction;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeItem;
-import org.eclipse.ui.IActionBars;
 import org.eclipse.ui.ISelectionListener;
 import org.eclipse.ui.IWorkbenchPart;
-import org.eclipse.ui.part.IPageSite;
 import org.eclipse.ui.views.contentoutline.ContentOutlinePage;
 
 import com.google.common.collect.ImmutableList;
@@ -80,13 +75,6 @@ public final class OutlinePage extends ContentOutlinePage {
         if (navigationBarItems.size() < 500) {
             treeViewer.expandAll();
         }
-
-        IPageSite site = getSite();
-        IActionBars actionBars = site.getActionBars();
-        IToolBarManager toolBarManager = actionBars.getToolBarManager();
-        toolBarManager.add(new CollapseAllAction(treeViewer));
-
-        toolBarManager.add(new ExpandAllAction());
 
         this.getSite().getWorkbenchWindow().getSelectionService().addPostSelectionListener(this.selectionListener);
     }


### PR DESCRIPTION
Reverts palantir/eclipse-typescript#258

Looks like this uses internal functionality:
Description	Resource	Path	Location	Type
Discouraged access: The constructor 'CollapseAllAction(TreeViewer)' is not API (restriction on required library '/Users/dcicerone/eclipse/plugins/org.eclipse.jdt.ui_3.10.2.v20141014-1419.jar')	OutlinePage.java	/com.palantir.typescript/src/com/palantir/typescript/text	line 87	Java Problem
Discouraged access: The constructor 'ExpandAllAction()' is not API (restriction on required library '/Users/dcicerone/eclipse/plugins/org.eclipse.search_3.9.100.v20140226-1637.jar')	OutlinePage.java	/com.palantir.typescript/src/com/palantir/typescript/text	line 89	Java Problem
Discouraged access: The type 'CollapseAllAction' is not API (restriction on required library '/Users/dcicerone/eclipse/plugins/org.eclipse.jdt.ui_3.10.2.v20141014-1419.jar')	OutlinePage.java	/com.palantir.typescript/src/com/palantir/typescript/text	line 23	Java Problem
Discouraged access: The type 'CollapseAllAction' is not API (restriction on required library '/Users/dcicerone/eclipse/plugins/org.eclipse.jdt.ui_3.10.2.v20141014-1419.jar')	OutlinePage.java	/com.palantir.typescript/src/com/palantir/typescript/text	line 87	Java Problem
Discouraged access: The type 'ExpandAllAction' is not API (restriction on required library '/Users/dcicerone/eclipse/plugins/org.eclipse.search_3.9.100.v20140226-1637.jar')	OutlinePage.java	/com.palantir.typescript/src/com/palantir/typescript/text	line 32	Java Problem
Discouraged access: The type 'ExpandAllAction' is not API (restriction on required library '/Users/dcicerone/eclipse/plugins/org.eclipse.search_3.9.100.v20140226-1637.jar')	OutlinePage.java	/com.palantir.typescript/src/com/palantir/typescript/text	line 89	Java Problem
