### PR TITLE
Fixes #269. Editor onSelectionChanged always select <global> in Outline

### DIFF
--- a/com.palantir.typescript/src/com/palantir/typescript/text/OutlinePage.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/text/OutlinePage.java
@@ -189,6 +189,11 @@ public final class OutlinePage extends ContentOutlinePage {
             boolean selected = false;
 
             for (TreeItem treeItem : treeItems) {
+
+                if ("<global>".equals(treeItem.getText())) {
+                    continue;
+                }
+
                 NavigationBarItem navigateToItem = (NavigationBarItem) treeItem.getData();
 
                 if (navigateToItem == null) {


### PR DESCRIPTION
Fixes #269. Editor onSelectionChanged always select <global> in Outline view.