### PR TITLE
Added support for tsc 1.6 option --suppressExcessPropertyErrors

### DIFF
--- a/com.palantir.typescript/src/com/palantir/typescript/IPreferenceConstants.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/IPreferenceConstants.java
@@ -40,8 +40,8 @@ public interface IPreferenceConstants {
     String COMPILER_OUT_DIR = "compiler.outputDirOption";
     String COMPILER_OUT_FILE = "compiler.outputFileOption";
     String COMPILER_REMOVE_COMMENTS = "compiler.removeComments";
-    String COMPILER_SUPPRESS_IMPLICIT_ANY_INDEX_ERRORS = "compiler.suppressImplicitAnyIndexErrors";
     String COMPILER_SUPPRESS_EXCESS_PROPERTY_ERRORS = "compiler.suppressExcessPropertyErrors";
+    String COMPILER_SUPPRESS_IMPLICIT_ANY_INDEX_ERRORS = "compiler.suppressImplicitAnyIndexErrors";
 
     String CONTENT_ASSIST_AUTO_ACTIVATION_DELAY = "contentAssist.autoActivationDelay";
     String CONTENT_ASSIST_AUTO_ACTIVATION_ENABLED = "contentAssist.autoActivationEnabled";

--- a/com.palantir.typescript/src/com/palantir/typescript/IPreferenceConstants.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/IPreferenceConstants.java
@@ -41,6 +41,7 @@ public interface IPreferenceConstants {
     String COMPILER_OUT_FILE = "compiler.outputFileOption";
     String COMPILER_REMOVE_COMMENTS = "compiler.removeComments";
     String COMPILER_SUPPRESS_IMPLICIT_ANY_INDEX_ERRORS = "compiler.suppressImplicitAnyIndexErrors";
+    String COMPILER_SUPPRESS_EXCESS_PROPERTY_ERRORS = "compiler.suppressExcessPropertyErrors";
 
     String CONTENT_ASSIST_AUTO_ACTIVATION_DELAY = "contentAssist.autoActivationDelay";
     String CONTENT_ASSIST_AUTO_ACTIVATION_ENABLED = "contentAssist.autoActivationEnabled";

--- a/com.palantir.typescript/src/com/palantir/typescript/TypeScriptPlugin.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/TypeScriptPlugin.java
@@ -156,6 +156,7 @@ public final class TypeScriptPlugin extends AbstractUIPlugin {
         store.setDefault(IPreferenceConstants.COMPILER_REMOVE_COMMENTS, false);
         store.setDefault(IPreferenceConstants.COMPILER_SOURCE_MAP, false);
         store.setDefault(IPreferenceConstants.COMPILER_SUPPRESS_IMPLICIT_ANY_INDEX_ERRORS, false);
+        store.setDefault(IPreferenceConstants.COMPILER_SUPPRESS_EXCESS_PROPERTY_ERRORS,  false);
         store.setDefault(IPreferenceConstants.COMPILER_TARGET, ScriptTarget.ECMASCRIPT5.toString());
 
         store.setDefault(IPreferenceConstants.CONTENT_ASSIST_AUTO_ACTIVATION_DELAY, 200);

--- a/com.palantir.typescript/src/com/palantir/typescript/TypeScriptPlugin.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/TypeScriptPlugin.java
@@ -155,8 +155,8 @@ public final class TypeScriptPlugin extends AbstractUIPlugin {
         store.setDefault(IPreferenceConstants.COMPILER_NO_LIB, false);
         store.setDefault(IPreferenceConstants.COMPILER_REMOVE_COMMENTS, false);
         store.setDefault(IPreferenceConstants.COMPILER_SOURCE_MAP, false);
-        store.setDefault(IPreferenceConstants.COMPILER_SUPPRESS_IMPLICIT_ANY_INDEX_ERRORS, false);
         store.setDefault(IPreferenceConstants.COMPILER_SUPPRESS_EXCESS_PROPERTY_ERRORS,  false);
+        store.setDefault(IPreferenceConstants.COMPILER_SUPPRESS_IMPLICIT_ANY_INDEX_ERRORS, false);
         store.setDefault(IPreferenceConstants.COMPILER_TARGET, ScriptTarget.ECMASCRIPT5.toString());
 
         store.setDefault(IPreferenceConstants.CONTENT_ASSIST_AUTO_ACTIVATION_DELAY, 200);

--- a/com.palantir.typescript/src/com/palantir/typescript/preferences/CompilerPreferencePage.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/preferences/CompilerPreferencePage.java
@@ -59,8 +59,8 @@ public final class CompilerPreferencePage extends FieldEditorProjectPreferencePa
     private BooleanFieldEditor noLibField;
     private BooleanFieldEditor removeCommentsField;
     private BooleanFieldEditor sourceMapField;
-    private BooleanFieldEditor suppressImplicitAnyIndexErrorsField;
     private BooleanFieldEditor suppressExcessPropertyErrorsField;
+    private BooleanFieldEditor suppressImplicitAnyIndexErrorsField;
     private ComboFieldEditor targetField;
 
     public CompilerPreferencePage() {
@@ -131,8 +131,8 @@ public final class CompilerPreferencePage extends FieldEditorProjectPreferencePa
                 || source.equals(this.noLibField)
                 || source.equals(this.removeCommentsField)
                 || source.equals(this.sourceMapField)
-                || source.equals(this.suppressImplicitAnyIndexErrorsField)
                 || source.equals(this.suppressExcessPropertyErrorsField)
+                || source.equals(this.suppressImplicitAnyIndexErrorsField)
                 || source.equals(this.targetField)) {
             this.compilerPreferencesModified = true;
         }
@@ -173,17 +173,17 @@ public final class CompilerPreferencePage extends FieldEditorProjectPreferencePa
             this.getFieldEditorParent());
         this.addField(this.noImplicitAnyField);
 
-        this.suppressImplicitAnyIndexErrorsField = new BooleanFieldEditor(
-            IPreferenceConstants.COMPILER_SUPPRESS_IMPLICIT_ANY_INDEX_ERRORS,
-            getResource("suppress.implicit.any.index.errors"),
-            this.getFieldEditorParent());
-        this.addField(this.suppressImplicitAnyIndexErrorsField);
-
         this.suppressExcessPropertyErrorsField = new BooleanFieldEditor(
             IPreferenceConstants.COMPILER_SUPPRESS_EXCESS_PROPERTY_ERRORS,
             getResource("suppress.excess.property.errors"),
             this.getFieldEditorParent());
         this.addField(this.suppressExcessPropertyErrorsField);
+
+        this.suppressImplicitAnyIndexErrorsField = new BooleanFieldEditor(
+            IPreferenceConstants.COMPILER_SUPPRESS_IMPLICIT_ANY_INDEX_ERRORS,
+            getResource("suppress.implicit.any.index.errors"),
+            this.getFieldEditorParent());
+        this.addField(this.suppressImplicitAnyIndexErrorsField);
 
         this.noLibField = new BooleanFieldEditor(
             IPreferenceConstants.COMPILER_NO_LIB,

--- a/com.palantir.typescript/src/com/palantir/typescript/preferences/CompilerPreferencePage.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/preferences/CompilerPreferencePage.java
@@ -60,6 +60,7 @@ public final class CompilerPreferencePage extends FieldEditorProjectPreferencePa
     private BooleanFieldEditor removeCommentsField;
     private BooleanFieldEditor sourceMapField;
     private BooleanFieldEditor suppressImplicitAnyIndexErrorsField;
+    private BooleanFieldEditor suppressExcessPropertyErrorsField;
     private ComboFieldEditor targetField;
 
     public CompilerPreferencePage() {
@@ -131,6 +132,7 @@ public final class CompilerPreferencePage extends FieldEditorProjectPreferencePa
                 || source.equals(this.removeCommentsField)
                 || source.equals(this.sourceMapField)
                 || source.equals(this.suppressImplicitAnyIndexErrorsField)
+                || source.equals(this.suppressExcessPropertyErrorsField)
                 || source.equals(this.targetField)) {
             this.compilerPreferencesModified = true;
         }
@@ -176,6 +178,12 @@ public final class CompilerPreferencePage extends FieldEditorProjectPreferencePa
             getResource("suppress.implicit.any.index.errors"),
             this.getFieldEditorParent());
         this.addField(this.suppressImplicitAnyIndexErrorsField);
+
+        this.suppressExcessPropertyErrorsField = new BooleanFieldEditor(
+            IPreferenceConstants.COMPILER_SUPPRESS_EXCESS_PROPERTY_ERRORS,
+            getResource("suppress.excess.property.errors"),
+            this.getFieldEditorParent());
+        this.addField(this.suppressExcessPropertyErrorsField);
 
         this.noLibField = new BooleanFieldEditor(
             IPreferenceConstants.COMPILER_NO_LIB,

--- a/com.palantir.typescript/src/com/palantir/typescript/resources.properties
+++ b/com.palantir.typescript/src/com/palantir/typescript/resources.properties
@@ -27,6 +27,7 @@ preferences.compiler.no.lib = Do not include the default library (lib.d.ts) when
 preferences.compiler.remove.comments = Do not emit comments to output
 preferences.compiler.source.map = Generate corresponding .map files
 preferences.compiler.suppress.implicit.any.index.errors = Suppress noImplicitAny errors for indexing objects lacking index signatures
+preferences.compiler.suppress.excess.property.errors = Suppress excess property errors
 preferences.compiler.target = ECMAScript target version:
 
 preferences.compiler.ecmascript3 = ES3

--- a/com.palantir.typescript/src/com/palantir/typescript/resources.properties
+++ b/com.palantir.typescript/src/com/palantir/typescript/resources.properties
@@ -26,8 +26,8 @@ preferences.compiler.no.implicit.any = Raise error on expressions and declaratio
 preferences.compiler.no.lib = Do not include the default library (lib.d.ts) when compiling
 preferences.compiler.remove.comments = Do not emit comments to output
 preferences.compiler.source.map = Generate corresponding .map files
-preferences.compiler.suppress.implicit.any.index.errors = Suppress noImplicitAny errors for indexing objects lacking index signatures
 preferences.compiler.suppress.excess.property.errors = Suppress excess property errors
+preferences.compiler.suppress.implicit.any.index.errors = Suppress noImplicitAny errors for indexing objects lacking index signatures
 preferences.compiler.target = ECMAScript target version:
 
 preferences.compiler.ecmascript3 = ES3

--- a/com.palantir.typescript/src/com/palantir/typescript/services/language/CompilerOptions.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/services/language/CompilerOptions.java
@@ -177,6 +177,7 @@ public final class CompilerOptions {
         compilationSettings.sourceMap = preferenceStore.getBoolean(IPreferenceConstants.COMPILER_SOURCE_MAP);
         compilationSettings.suppressImplicitAnyIndexErrors = preferenceStore
             .getBoolean(IPreferenceConstants.COMPILER_SUPPRESS_IMPLICIT_ANY_INDEX_ERRORS);
+        compilationSettings.suppressExcessPropertyErrors = preferenceStore.getBoolean(IPreferenceConstants.COMPILER_SUPPRESS_EXCESS_PROPERTY_ERRORS);
         compilationSettings.target = ScriptTarget.valueOf(preferenceStore.getString(IPreferenceConstants.COMPILER_TARGET));
 
         // set the output directory or file if it was specified

--- a/com.palantir.typescript/src/com/palantir/typescript/services/language/CompilerOptions.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/services/language/CompilerOptions.java
@@ -175,9 +175,9 @@ public final class CompilerOptions {
         compilationSettings.noLib = preferenceStore.getBoolean(IPreferenceConstants.COMPILER_NO_LIB);
         compilationSettings.removeComments = preferenceStore.getBoolean(IPreferenceConstants.COMPILER_REMOVE_COMMENTS);
         compilationSettings.sourceMap = preferenceStore.getBoolean(IPreferenceConstants.COMPILER_SOURCE_MAP);
+        compilationSettings.suppressExcessPropertyErrors = preferenceStore.getBoolean(IPreferenceConstants.COMPILER_SUPPRESS_EXCESS_PROPERTY_ERRORS);
         compilationSettings.suppressImplicitAnyIndexErrors = preferenceStore
             .getBoolean(IPreferenceConstants.COMPILER_SUPPRESS_IMPLICIT_ANY_INDEX_ERRORS);
-        compilationSettings.suppressExcessPropertyErrors = preferenceStore.getBoolean(IPreferenceConstants.COMPILER_SUPPRESS_EXCESS_PROPERTY_ERRORS);
         compilationSettings.target = ScriptTarget.valueOf(preferenceStore.getString(IPreferenceConstants.COMPILER_TARGET));
 
         // set the output directory or file if it was specified


### PR DESCRIPTION
Added new preference to enable suppression of the new typescript 1.6 excess property error checks. 