### PR TITLE
Add nodejs module resolution compiler option

### DIFF
--- a/com.palantir.typescript/src/com/palantir/typescript/IPreferenceConstants.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/IPreferenceConstants.java
@@ -36,6 +36,7 @@ public interface IPreferenceConstants {
     String COMPILER_JSX = "compiler.jsx";
     String COMPILER_SOURCE_MAP = "compiler.mapSourceFiles";
     String COMPILER_MODULE = "compiler.moduleGenTarget";
+    String COMPILER_MODULE_RESOLUTION = "compiler.moduleResolution";
     String COMPILER_NO_EMIT_ON_ERROR = "compiler.noEmitOnError";
     String COMPILER_NO_FALLTHROUGH_CASES_IN_SWITCH = "compiler.noFallthroughCasesInSwitch";
     String COMPILER_NO_IMPLICIT_ANY = "compiler.noImplicitAny";

--- a/com.palantir.typescript/src/com/palantir/typescript/TypeScriptPlugin.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/TypeScriptPlugin.java
@@ -40,6 +40,7 @@ import com.palantir.typescript.services.language.IndentStyle;
 import com.palantir.typescript.services.language.JsxEmit;
 import com.palantir.typescript.services.language.LanguageEndpoint;
 import com.palantir.typescript.services.language.ModuleKind;
+import com.palantir.typescript.services.language.ModuleResolutionKind;
 import com.palantir.typescript.services.language.ScriptTarget;
 
 /**
@@ -154,6 +155,7 @@ public final class TypeScriptPlugin extends AbstractUIPlugin {
         store.setDefault(IPreferenceConstants.COMPILER_INLINE_SOURCES, false);
         store.setDefault(IPreferenceConstants.COMPILER_JSX, JsxEmit.NONE.toString());
         store.setDefault(IPreferenceConstants.COMPILER_MODULE, ModuleKind.NONE.toString());
+        store.setDefault(IPreferenceConstants.COMPILER_MODULE_RESOLUTION, ModuleResolutionKind.CLASSIC.toString());
         store.setDefault(IPreferenceConstants.COMPILER_NO_FALLTHROUGH_CASES_IN_SWITCH, false);
         store.setDefault(IPreferenceConstants.COMPILER_NO_IMPLICIT_ANY, false);
         store.setDefault(IPreferenceConstants.COMPILER_NO_IMPLICIT_RETURNS, false);

--- a/com.palantir.typescript/src/com/palantir/typescript/preferences/CompilerPreferencePage.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/preferences/CompilerPreferencePage.java
@@ -38,6 +38,7 @@ import com.palantir.typescript.Resources;
 import com.palantir.typescript.TypeScriptPlugin;
 import com.palantir.typescript.services.language.JsxEmit;
 import com.palantir.typescript.services.language.ModuleKind;
+import com.palantir.typescript.services.language.ModuleResolutionKind;
 import com.palantir.typescript.services.language.ScriptTarget;
 
 /**
@@ -56,6 +57,7 @@ public final class CompilerPreferencePage extends FieldEditorProjectPreferencePa
     private BooleanFieldEditor inlineSourcesField;
     private ComboFieldEditor jsxField;
     private ComboFieldEditor moduleField;
+    private ComboFieldEditor moduleResolutionField;
     private BooleanFieldEditor noEmitOnErrorField;
     private BooleanFieldEditor noFallthroughCasesInSwitchField;
     private BooleanFieldEditor noImplicitAnyField;
@@ -135,6 +137,7 @@ public final class CompilerPreferencePage extends FieldEditorProjectPreferencePa
                 || source.equals(this.inlineSourcesField)
                 || source.equals(this.jsxField)
                 || source.equals(this.moduleField)
+                || source.equals(this.moduleResolutionField)
                 || source.equals(this.noEmitOnErrorField)
                 || source.equals(this.noFallthroughCasesInSwitchField)
                 || source.equals(this.noImplicitAnyField)
@@ -171,6 +174,13 @@ public final class CompilerPreferencePage extends FieldEditorProjectPreferencePa
             this.createComboFieldValues(ModuleKind.values()),
             this.getFieldEditorParent());
         this.addField(this.moduleField);
+
+        this.moduleResolutionField = new ComboFieldEditor(
+            IPreferenceConstants.COMPILER_MODULE_RESOLUTION,
+            getResource("module.resolution"),
+            this.createComboFieldValues(ModuleResolutionKind.values()),
+            this.getFieldEditorParent());
+        this.addField(this.moduleResolutionField);
 
         this.noEmitOnErrorField = new BooleanFieldEditor(
             IPreferenceConstants.COMPILER_NO_EMIT_ON_ERROR,

--- a/com.palantir.typescript/src/com/palantir/typescript/resources.properties
+++ b/com.palantir.typescript/src/com/palantir/typescript/resources.properties
@@ -23,6 +23,7 @@ preferences.compiler.inline.source.map = Inline source map
 preferences.compiler.inline.sources = Inline sources in source map
 preferences.compiler.jsx = Specify JSX code generation:
 preferences.compiler.module = Module code generation:
+preferences.compiler.module.resolution = Module resolution:
 preferences.compiler.no.emit.on.error = Do not emit outputs if any type checking errors were reported
 preferences.compiler.no.fallthrough.cases.in.switch = Report errors for fallthrough cases in switch statement
 preferences.compiler.no.implicit.any = Report an error on expressions and declarations with an implied 'any' type
@@ -44,6 +45,9 @@ preferences.compiler.es6 = ES6
 preferences.compiler.none = None
 preferences.compiler.system = System
 preferences.compiler.umd = UMD
+
+preferences.compiler.classic = Classic
+preferences.compiler.node.js = NodeJs
 
 preferences.compiler.preserve = Preserve
 preferences.compiler.react = React

--- a/com.palantir.typescript/src/com/palantir/typescript/services/language/CompilerOptions.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/services/language/CompilerOptions.java
@@ -201,7 +201,8 @@ public final class CompilerOptions {
         compilerOptions.inlineSources = preferenceStore.getBoolean(IPreferenceConstants.COMPILER_INLINE_SOURCES);
         compilerOptions.jsx = JsxEmit.valueOf(preferenceStore.getString(IPreferenceConstants.COMPILER_JSX));
         compilerOptions.module = ModuleKind.parse(preferenceStore.getString(IPreferenceConstants.COMPILER_MODULE));
-        compilerOptions.moduleResolution = ModuleResolutionKind.CLASSIC;
+        compilerOptions.moduleResolution = ModuleResolutionKind
+            .valueOf(preferenceStore.getString(IPreferenceConstants.COMPILER_MODULE_RESOLUTION));
         compilerOptions.noEmitOnError = preferenceStore.getBoolean(IPreferenceConstants.COMPILER_NO_EMIT_ON_ERROR);
         compilerOptions.noFallthroughCasesInSwitch = preferenceStore
             .getBoolean(IPreferenceConstants.COMPILER_NO_FALLTHROUGH_CASES_IN_SWITCH);

--- a/com.palantir.typescript/src/com/palantir/typescript/services/language/ModuleResolutionKind.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/services/language/ModuleResolutionKind.java
@@ -25,12 +25,17 @@ import com.fasterxml.jackson.annotation.JsonValue;
  */
 public enum ModuleResolutionKind {
 
-    NONE,
-    CLASSIC,
-    NODE_JS;
+    CLASSIC(1),
+    NODE_JS(2);
+
+    private final int value;
+
+    ModuleResolutionKind(int value) {
+        this.value = value;
+    }
 
     @JsonValue
     public int getValue() {
-        return this.ordinal();
+        return this.value;
     }
 }


### PR DESCRIPTION
-- Does not support node_modules outside the
   project folder
-- Included library has to be specified by
   adding it to the Source Folder. The path
   to the folder containing the package.json
   file should be specified. It is therefore
   preferrable to install the library typings
   into the typings folder using typings.
-- This addresses #301 (partially).