### PR TITLE
Fixes #313

### DIFF
--- a/com.palantir.typescript/META-INF/MANIFEST.MF
+++ b/com.palantir.typescript/META-INF/MANIFEST.MF
@@ -18,7 +18,8 @@ Require-Bundle: org.eclipse.compare,
  org.eclipse.ui.editors,
  org.eclipse.ui.ide,
  org.eclipse.ui.views,
- org.eclipse.ui.workbench.texteditor
+ org.eclipse.ui.workbench.texteditor,
+ org.eclipse.jdt.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: lib/guava-19.0.jar,

--- a/com.palantir.typescript/src/com/palantir/typescript/IPreferenceConstants.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/IPreferenceConstants.java
@@ -16,6 +16,7 @@
 
 package com.palantir.typescript;
 
+import org.eclipse.jdt.ui.PreferenceConstants;
 
 /**
  * The preference constants used for handling preferences.
@@ -56,8 +57,8 @@ public interface IPreferenceConstants {
     String EDITOR_CLOSE_JSDOCS = "editor.closeJSDocs";
     String EDITOR_INDENT_SIZE = "editor.indentSize";
     String EDITOR_INDENT_STYLE = "editor.indentStyle";
-    String EDITOR_MATCHING_BRACKETS = "editor.matchingBrackets";
-    String EDITOR_MATCHING_BRACKETS_COLOR = "editor.matchingBracketsColor";
+    String EDITOR_MATCHING_BRACKETS = PreferenceConstants.EDITOR_MATCHING_BRACKETS;
+    String EDITOR_MATCHING_BRACKETS_COLOR = PreferenceConstants.EDITOR_MATCHING_BRACKETS_COLOR;
 
     String FORMATTER_INSERT_SPACE_AFTER_COMMA_DELIMITER = "formatter.insertSpaceAfterCommaDelimiter";
     String FORMATTER_INSERT_SPACE_AFTER_FUNCTION_KEYWORD_FOR_ANONYMOUS_FUNCTIONS = "formatter.insertSpaceAfterFunctionKeywordForAnonymousFunctions";

--- a/com.palantir.typescript/src/com/palantir/typescript/text/TypeScriptEditor.java
+++ b/com.palantir.typescript/src/com/palantir/typescript/text/TypeScriptEditor.java
@@ -25,6 +25,7 @@ import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.jdt.ui.PreferenceConstants;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.DocumentEvent;
@@ -158,12 +159,16 @@ public final class TypeScriptEditor extends TextEditor {
     public void init(IEditorSite site, IEditorInput input) throws PartInitException {
         super.init(site, input);
 
+        this.characterPairMatcher = createCharacterPairMatcher();
+
         if (input instanceof IPathEditorInput) {
             IResource resource = ResourceUtil.getResource(input);
             IProject project = resource.getProject();
 
             // set a project-specific preference store
             ChainedPreferenceStore chainedPreferenceStore = new ChainedPreferenceStore(new IPreferenceStore[] {
+                    PreferenceConstants.getPreferenceStore(),
+                    TypeScriptPlugin.getDefault().getPreferenceStore(),
                     new ProjectPreferenceStore(project),
                     EditorsUI.getPreferenceStore(),
                     PlatformUI.getPreferenceStore()
@@ -223,11 +228,11 @@ public final class TypeScriptEditor extends TextEditor {
 
     @Override
     protected void configureSourceViewerDecorationSupport(SourceViewerDecorationSupport support) {
-        super.configureSourceViewerDecorationSupport(support);
-
         support.setCharacterPairMatcher(this.characterPairMatcher);
         support.setMatchingCharacterPainterPreferenceKeys(IPreferenceConstants.EDITOR_MATCHING_BRACKETS,
             IPreferenceConstants.EDITOR_MATCHING_BRACKETS_COLOR);
+
+        super.configureSourceViewerDecorationSupport(support);
     }
 
     @Override
@@ -286,21 +291,6 @@ public final class TypeScriptEditor extends TextEditor {
         sourceViewer.addTextInputListener(new MyListener());
 
         return sourceViewer;
-    }
-
-    @Override
-    protected void initializeEditor() {
-        super.initializeEditor();
-
-        this.characterPairMatcher = createCharacterPairMatcher();
-
-        // set the preference store
-        ChainedPreferenceStore chainedPreferenceStore = new ChainedPreferenceStore(new IPreferenceStore[] {
-                TypeScriptPlugin.getDefault().getPreferenceStore(),
-                EditorsUI.getPreferenceStore(),
-                PlatformUI.getPreferenceStore()
-        });
-        this.setPreferenceStore(chainedPreferenceStore);
     }
 
     @Override


### PR DESCRIPTION
Matching bracket color now uses JDT preference color. Wich can be
changed in Windows->Preferences->Java->Editor->Matching Bracket
Highlight

I could not find the Javascript exposed preference store.